### PR TITLE
Add IDLE like code blocks

### DIFF
--- a/src/pytest_codeblocks/main.py
+++ b/src/pytest_codeblocks/main.py
@@ -108,7 +108,7 @@ def extract_from_buffer(f, max_num_lines: int = 10000):
                     out[-1].expected_output,
                     out[-1].expect_exception,
                 )
-            elif keyword in ["expect-exception", "expect-error", "expect-return"]:
+            elif keyword in ["expect-exception", "expect-error"]:
                 out.append(
                     CodeBlock(
                         "".join(code_block), lineno, syntax, expect_exception=True

--- a/src/pytest_codeblocks/main.py
+++ b/src/pytest_codeblocks/main.py
@@ -108,7 +108,7 @@ def extract_from_buffer(f, max_num_lines: int = 10000):
                     out[-1].expected_output,
                     out[-1].expect_exception,
                 )
-            elif keyword in ["expect-exception", "expect-error"]:
+            elif keyword in ["expect-exception", "expect-error", "expect-return"]:
                 out.append(
                     CodeBlock(
                         "".join(code_block), lineno, syntax, expect_exception=True

--- a/src/pytest_codeblocks/plugin.py
+++ b/src/pytest_codeblocks/plugin.py
@@ -72,11 +72,12 @@ class Codeblock(pytest.Item):
         elif self.obj.syntax == "idle-return":
             assert len(self.obj.code.splitlines()) == 2, "Expect input and return line"
             code_striped = self.obj.code.splitlines()[0].lstrip(">>>").strip()
+            expected_return = self.obj.code.splitlines()[1]
             if not code_striped.startswith("print"):
                 self.obj.code = "print(" + code_striped + ")"
             else:
                 self.obj.code = code_striped
-            self.obj.expected_output = self.obj.code.splitlines()[1]
+            self.obj.expected_output = expected_return
             output = self.run_python()
         else:
             assert self.obj.syntax in ["sh", "bash"]

--- a/src/pytest_codeblocks/plugin.py
+++ b/src/pytest_codeblocks/plugin.py
@@ -77,7 +77,7 @@ class Codeblock(pytest.Item):
                 self.obj.code = "print(" + code_striped + ")"
             else:
                 self.obj.code = code_striped
-            self.obj.expected_output = expected_return
+            self.obj.expected_output = expected_return + "\n"
             output = self.run_python()
         else:
             assert self.obj.syntax in ["sh", "bash"]

--- a/src/pytest_codeblocks/plugin.py
+++ b/src/pytest_codeblocks/plugin.py
@@ -70,13 +70,13 @@ class Codeblock(pytest.Item):
             self.obj.code = code_striped
             output = self.run_python()
         elif self.obj.syntax == "idle-return":
-            assert len(self.obj.code) == 2, "Expect input and return line"
-            code_striped = self.obj.code[0].lstrip(">>>").strip()
+            assert len(self.obj.code.splitlines()) == 2, "Expect input and return line"
+            code_striped = self.obj.code.splitlines()[0].lstrip(">>>").strip()
             if not code_striped.startswith("print"):
                 self.obj.code = "print(" + code_striped + ")"
             else:
                 self.obj.code = code_striped
-            self.obj.expected_output = self.obj.code[1]
+            self.obj.expected_output = self.obj.code.splitlines()[1]
             output = self.run_python()
         else:
             assert self.obj.syntax in ["sh", "bash"]

--- a/tests/test_idle.py
+++ b/tests/test_idle.py
@@ -15,7 +15,7 @@ def test_idle_fail(testdir):
     string = """
     ```idle
     >>> print("abc)
-    SyntaxError: 
+    SyntaxError:
     ```
     """
     testdir.makefile(".md", string)
@@ -28,7 +28,7 @@ def test_idle_expect_fail_passed(testdir):
     <!--pytest-codeblocks:expect-error-->
     ```idle
     >>> print("abc)
-    SyntaxError: 
+    SyntaxError:
     ```
     """
     testdir.makefile(".md", string)

--- a/tests/test_idle.py
+++ b/tests/test_idle.py
@@ -38,8 +38,7 @@ def test_idle_expect_fail_passed(testdir):
 
 def test_idle_expected_return_fail(testdir):
     string = """
-    <!--pytest-codeblocks:expect-return-->
-    ```idle
+    ```idle-return
     >>> 5 + 7
     13
     ```
@@ -50,8 +49,7 @@ def test_idle_expected_return_fail(testdir):
 
 def test_idle_expected_return(testdir):
     string = """
-    <!--pytest-codeblocks:expect-return-->
-    ```idle
+    ```idle-return
     >>> 5 + 7
     12
     ```

--- a/tests/test_idle.py
+++ b/tests/test_idle.py
@@ -47,6 +47,7 @@ def test_idle_expected_return_fail(testdir):
     result = testdir.runpytest("--codeblocks")
     result.assert_outcomes(failed=1)
 
+    
 def test_idle_expected_return(testdir):
     string = """
     ```idle-return

--- a/tests/test_idle.py
+++ b/tests/test_idle.py
@@ -1,0 +1,61 @@
+def test_idle(testdir):
+    string = """
+    Lorem ipsum
+    ```idle
+    >>> 5 + 7
+    12
+    ```
+    """
+    testdir.makefile(".md", string)
+    result = testdir.runpytest("--codeblocks")
+    result.assert_outcomes(passed=1)
+
+
+def test_idle_fail(testdir):
+    string = """
+    ```idle
+    >>> print("abc)
+    SyntaxError: 
+    ```
+    """
+    testdir.makefile(".md", string)
+    result = testdir.runpytest("--codeblocks")
+    result.assert_outcomes(failed=1)
+
+
+def test_idle_expect_fail_passed(testdir):
+    string = """
+    <!--pytest-codeblocks:expect-error-->
+    ```idle
+    >>> print("abc)
+    SyntaxError: 
+    ```
+    """
+    testdir.makefile(".md", string)
+    result = testdir.runpytest("--codeblocks")
+    result.assert_outcomes(passed=1)
+
+
+def test_idle_expected_return_fail(testdir):
+    string = """
+    <!--pytest-codeblocks:expect-return-->
+    ```idle
+    >>> 5 + 7
+    13
+    ```
+    """
+    testdir.makefile(".md", string)
+    result = testdir.runpytest("--codeblocks")
+    result.assert_outcomes(failed=1)
+
+def test_idle_expected_return(testdir):
+    string = """
+    <!--pytest-codeblocks:expect-return-->
+    ```idle
+    >>> 5 + 7
+    12
+    ```
+    """
+    testdir.makefile(".md", string)
+    result = testdir.runpytest("--codeblocks")
+    result.assert_outcomes(passed=1)

--- a/tests/test_idle.py
+++ b/tests/test_idle.py
@@ -47,7 +47,7 @@ def test_idle_expected_return_fail(testdir):
     result = testdir.runpytest("--codeblocks")
     result.assert_outcomes(failed=1)
 
-    
+
 def test_idle_expected_return(testdir):
     string = """
     ```idle-return


### PR DESCRIPTION
Now allows displaying (and testing) IDLE like code blocks:

```idle
>>> 77 / 11
7.0
```

like this: 
````
```idle
>>> 77 / 11
7.0
```
````

or with testing the returned value by:
like this: 
````
```idle-return
>>> 77 / 11
7.0
```
````

Still doesn't solve things like this
```
>>> for i in range(4):
        print(i**2)

0
1
4
9
```