### PR TITLE
Allow different markdown comment styles.

### DIFF
--- a/src/pytest_codeblocks/main.py
+++ b/src/pytest_codeblocks/main.py
@@ -70,14 +70,14 @@ def extract_from_buffer(f, max_num_lines: int = 10000):
 
             # check for keywords
             m = re.match(
-                r"<!--\-?\s?pytest-codeblocks:(.*)\-?\s?-->",
+                r"<!\-{2,}\s*pytest-codeblocks:(.*)\-{2,}>",
                 previous_nonempty_line.strip(),
             )
             if m is None:
                 out.append(CodeBlock("".join(code_block), lineno, syntax))
                 continue
 
-            keyword = m.group(1).strip()
+            keyword = m.group(1).strip("- ")
 
             # handle special tags
             if keyword == "skip":

--- a/src/pytest_codeblocks/main.py
+++ b/src/pytest_codeblocks/main.py
@@ -70,13 +70,13 @@ def extract_from_buffer(f, max_num_lines: int = 10000):
 
             # check for keywords
             m = re.match(
-                "<!--pytest-codeblocks:(.*)-->", previous_nonempty_line.strip()
+                "<!--\-?\s?pytest-codeblocks:(.*)\-?\s?-->", previous_nonempty_line.strip()
             )
             if m is None:
                 out.append(CodeBlock("".join(code_block), lineno, syntax))
                 continue
 
-            keyword = m.group(1)
+            keyword = m.group(1).strip()
 
             # handle special tags
             if keyword == "skip":

--- a/src/pytest_codeblocks/main.py
+++ b/src/pytest_codeblocks/main.py
@@ -70,7 +70,8 @@ def extract_from_buffer(f, max_num_lines: int = 10000):
 
             # check for keywords
             m = re.match(
-                "<!--\-?\s?pytest-codeblocks:(.*)\-?\s?-->", previous_nonempty_line.strip()
+                "<!--\-?\s?pytest-codeblocks:(.*)\-?\s?-->",
+                previous_nonempty_line.strip()
             )
             if m is None:
                 out.append(CodeBlock("".join(code_block), lineno, syntax))

--- a/src/pytest_codeblocks/main.py
+++ b/src/pytest_codeblocks/main.py
@@ -70,7 +70,7 @@ def extract_from_buffer(f, max_num_lines: int = 10000):
 
             # check for keywords
             m = re.match(
-                "<!--\-?\s?pytest-codeblocks:(.*)\-?\s?-->",
+                r"<!--\-?\s?pytest-codeblocks:(.*)\-?\s?-->",
                 previous_nonempty_line.strip(),
             )
             if m is None:

--- a/src/pytest_codeblocks/main.py
+++ b/src/pytest_codeblocks/main.py
@@ -70,7 +70,7 @@ def extract_from_buffer(f, max_num_lines: int = 10000):
 
             # check for keywords
             m = re.match(
-                r"<!\-{2,}\s*pytest-codeblocks:(.*)\-{2,}>",
+                r"<!--[-\s]*pytest-codeblocks:(.*)-->",
                 previous_nonempty_line.strip(),
             )
             if m is None:

--- a/src/pytest_codeblocks/main.py
+++ b/src/pytest_codeblocks/main.py
@@ -71,7 +71,7 @@ def extract_from_buffer(f, max_num_lines: int = 10000):
             # check for keywords
             m = re.match(
                 "<!--\-?\s?pytest-codeblocks:(.*)\-?\s?-->",
-                previous_nonempty_line.strip()
+                previous_nonempty_line.strip(),
             )
             if m is None:
                 out.append(CodeBlock("".join(code_block), lineno, syntax))

--- a/tests/test_comment_styles.py
+++ b/tests/test_comment_styles.py
@@ -1,0 +1,24 @@
+import pytest
+
+
+@pytest.mark.parametrize("comment", [
+    "<!--pytest-codeblocks:cont-->",
+    "<!---pytest-codeblocks:cont--->",
+    "<!-- pytest-codeblocks:cont -->",
+    "<!--- pytest-codeblocks:cont --->"
+    ])
+def test_cont(testdir, comment):
+    string = """
+    Lorem ipsum
+    ```python
+    a = 1
+    ```
+    dolor sit amet
+    {comment}
+    ```
+    a + 1
+    ```
+    """
+    testdir.makefile(".md", string)
+    result = testdir.runpytest("--codeblocks")
+    result.assert_outcomes(passed=1)

--- a/tests/test_comment_styles.py
+++ b/tests/test_comment_styles.py
@@ -1,12 +1,15 @@
 import pytest
 
 
-@pytest.mark.parametrize("comment", [
-    "<!--pytest-codeblocks:cont-->",
-    "<!---pytest-codeblocks:cont--->",
-    "<!-- pytest-codeblocks:cont -->",
-    "<!--- pytest-codeblocks:cont --->"
-    ])
+@pytest.mark.parametrize(
+    "comment",
+    [
+        "<!--pytest-codeblocks:cont-->",
+        "<!---pytest-codeblocks:cont--->",
+        "<!-- pytest-codeblocks:cont -->",
+        "<!--- pytest-codeblocks:cont --->",
+    ],
+)
 def test_cont(testdir, comment):
     string = """
     Lorem ipsum


### PR DESCRIPTION
I encountered problems when working with markdown tools such as `Typora` which only accepted markdown comments of the style `<!-- comment... --!>`.

In general, the following forms seem to be common practice: 
+ `<!--comment--!>`
+ `<!-- comment --!>`
+ `<!---comment---!>`
+ `<!--- comment ---!>`
(see also: https://gist.github.com/jonikarppinen/47dc8c1d7ab7e911f4c9)

I hence changed the regex to accommodate all four types.
(and added a test function)